### PR TITLE
Added functionility to send new Ajax options from the <shouldRetry> meth...

### DIFF
--- a/src/jQuery.ajaxRetry.js
+++ b/src/jQuery.ajaxRetry.js
@@ -84,7 +84,20 @@
         (function tryRequest( options, lastJqXHR, finalizer ) {
             // If lastJqXHR === undefined at this point, then it's the first ever request.
             // Ensure that we always proceed without calling the shouldRetry function in that case
-            ( !lastJqXHR ? $.when(true) : shouldRetry(lastJqXHR, retryCount++, options.type || "GET") ).done(function( willRetry ) {
+            ( !lastJqXHR ? $.when(true) : shouldRetry(lastJqXHR, retryCount++, options.type || "GET") ).done(function( retryOptions ) {
+                var willRetry = false;
+                if ($.type(retryOptions) === "boolean"){
+                    // if the returned value is a boolean, then set willRetry to that value
+                    willRetry = retryOptions;
+                } else if ($.type(retryOptions) === "object"){
+                    // if it's an object, then set willRetry from the willRetry property, 
+                    // remove it from the properties and extend the options
+                    willRetry = retryOptions.willRetry;
+                    delete retryOptions.willRetry;
+                    
+                    // extend the options
+                    $.extend(options, retryOptions);
+                }
                 if ( willRetry === true ) {
                     (!lastJqXHR ? jqXHR : $.ajax(options) ).then(
                         function( data, textStatus, jqXHR ) {


### PR DESCRIPTION
Needed a way to update the timeout value within the shouldRetry method.  Decided to allow to return a boolean or object to the <done> method.  The object must contain a boolean called <willRetry> and any other ajax option properties that should be overridden.

I have not added any unit-tests to this fork but if you like the idea I can create some.
